### PR TITLE
ci: workflow does not contain default permissions

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,4 +1,6 @@
 name: cache
+permissions:
+  contents: read
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/evva-sfw/evva-sfw.github.io/security/code-scanning/1](https://github.com/evva-sfw/evva-sfw.github.io/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key at the workflow or job level with the least required privileges. Since the job references a reusable workflow (via `uses:`), you should specify a restrictive permissions block unless the workflow requires specific elevated permissions. The most restrictive default is `permissions: {}` (no permissions), but commonly for workflows that only need to read repository contents, use `permissions: contents: read`. For cache cleanup, if no write actions to the repository are required (such as pushing commits or creating/modifying PRs), `contents: read` is appropriate and secure. Insert the `permissions:` block at the top level (for the entire workflow) or under the `cache_cleanup` job block (for just this job).

Specifically, in `.github/workflows/cache.yml`, add:
```yaml
permissions:
  contents: read
```
just after the `name:` field and before the `on:` block to cover the entire workflow (unless a more restrictive or permissive setting is genuinely needed).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
