### PR TITLE
chore: added entry for new Xesar version

### DIFF
--- a/src/content/docs/XesarSoftware/api.mdx
+++ b/src/content/docs/XesarSoftware/api.mdx
@@ -13,6 +13,7 @@ sidebar:
 
 | Xesar Version | Xesar Backend Version | API Version | Download Link                                                                         |
 |---------------|-----------------------|-------------|---------------------------------------------------------------------------------------|
+| 3.4.10        | 10.10.0               | 1.74.0      | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.74.0.zip) |
 | 3.3.108       | 9.11.0                | 1.54.1      | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.54.1.zip) |
 | 3.3.27        | 8.24.0                | 1.37.0      | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.37.0.zip) |
 | 3.2.21        | 7.41.0                | 1.22.0      | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.22.0.zip) |
@@ -21,5 +22,4 @@ sidebar:
 | 3.1.126       | 6.27.0                | 1.2.1       | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.2.1.zip)  |
 | 3.1.124       | 6.27.0                | 1.2.1       | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.2.1.zip)  |
 | 3.1.122       | 6.26.0                | 1.2.1       | [Download](https://swdelivery.blob.core.windows.net/xs3-docs/xs3-mqtt-doc-1.2.1.zip)  |
-
 


### PR DESCRIPTION
Adds an entry with the download link for the API of the newest released Xesar version.